### PR TITLE
Swap lib out for iOS, bump min iOS version + fix Apple Silicon build

### DIFF
--- a/ios/flutter_video_cast.podspec
+++ b/ios/flutter_video_cast.podspec
@@ -20,6 +20,6 @@ A new flutter plugin project.
   s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  # s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
 end

--- a/ios/flutter_video_cast.podspec
+++ b/ios/flutter_video_cast.podspec
@@ -15,11 +15,11 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'google-cast-sdk-no-bluetooth'
-  s.platform = :ios, '11.0'
+  s.dependency 'google-cast-sdk-dynamic-xcframework-no-bluetooth'
+  s.platform = :ios, '12.0'
   s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
-  # s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  # s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
   s.swift_version = '5.0'
 end

--- a/ios/flutter_video_cast.podspec
+++ b/ios/flutter_video_cast.podspec
@@ -20,6 +20,6 @@ A new flutter plugin project.
   s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
 end


### PR DESCRIPTION

### Main issue was that prior to this change, build was failing on ARM Mac (M2) iOS
I tried excluding arm64 from Xcode architectures on debug build, but that then presented the scrolling/inertia bug with Flutter where it became unusable.

So:
- Swapping out the pod on iOS for google-cast-sdk-dynamic-xcframework-no-bluetooth
- Bump min iOS to 12 (from 11) and fix build on Apple Silicon

This fixes the iOS build (without excluding arm64) + scrolling bug not present in simulator.
